### PR TITLE
Allow access to dispose even in private classes

### DIFF
--- a/src/main/java/org/nnsoft/guice/lifegycle/Disposer.java
+++ b/src/main/java/org/nnsoft/guice/lifegycle/Disposer.java
@@ -121,8 +121,12 @@ public final class Disposer
          */
         public Disposable( Method disposeMethod, Object injectee )
         {
+        	if (!disposeMethod.isAccessible()) {
+        		disposeMethod.setAccessible(true);
+        	}
+        	
             this.disposeMethod = disposeMethod;
-            this.injectee = injectee;
+            this.injectee = injectee;                       
         }
 
         /**

--- a/src/test/java/org/nnsoft/guice/lifegycle/PrivateDisposeTestCase.java
+++ b/src/test/java/org/nnsoft/guice/lifegycle/PrivateDisposeTestCase.java
@@ -1,0 +1,39 @@
+package org.nnsoft.guice.lifegycle;
+
+import static com.google.inject.Guice.createInjector;
+import static junit.framework.Assert.assertTrue;
+import static junit.framework.Assert.fail;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.nnsoft.guice.lifegycle.test.IPrivateDisposeInterface;
+import org.nnsoft.guice.lifegycle.test.PrivateDisposeModule;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.ConfigurationException;
+import com.google.inject.Inject;
+
+public final class PrivateDisposeTestCase
+{
+    @Inject
+    private IPrivateDisposeInterface privateDisposeInterface;    
+    
+    @Inject
+    private Disposer disposer;
+
+    
+    @Before
+    public void setUp()
+    {
+        createInjector( new DisposeModule(), new PrivateDisposeModule() )
+        .getMembersInjector( PrivateDisposeTestCase.class )
+        .injectMembers( this );
+    }
+
+    @Test
+    public void disposeMethodInvoked()
+    {
+        disposer.dispose();
+        assertTrue( privateDisposeInterface.getDisposedCalled() );
+    }    
+}

--- a/src/test/java/org/nnsoft/guice/lifegycle/test/IPrivateDisposeInterface.java
+++ b/src/test/java/org/nnsoft/guice/lifegycle/test/IPrivateDisposeInterface.java
@@ -1,0 +1,5 @@
+package org.nnsoft.guice.lifegycle.test;
+
+public interface IPrivateDisposeInterface {
+	public boolean getDisposedCalled();
+}

--- a/src/test/java/org/nnsoft/guice/lifegycle/test/PrivateDisposeClass.java
+++ b/src/test/java/org/nnsoft/guice/lifegycle/test/PrivateDisposeClass.java
@@ -1,0 +1,19 @@
+package org.nnsoft.guice.lifegycle.test;
+
+import org.nnsoft.guice.lifegycle.Dispose;
+
+class PrivateDisposeClass implements IPrivateDisposeInterface {
+
+	private boolean disposeCalled = false;
+	
+	public boolean getDisposedCalled()
+	{
+		return this.disposeCalled;
+	}
+	
+	@Dispose
+	public void close()
+	{
+		this.disposeCalled = true;
+	}
+}

--- a/src/test/java/org/nnsoft/guice/lifegycle/test/PrivateDisposeModule.java
+++ b/src/test/java/org/nnsoft/guice/lifegycle/test/PrivateDisposeModule.java
@@ -1,0 +1,13 @@
+package org.nnsoft.guice.lifegycle.test;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Singleton;
+
+public class PrivateDisposeModule extends AbstractModule {
+
+	@Override
+	protected void configure() {
+		bind(IPrivateDisposeInterface.class).to(PrivateDisposeClass.class).in(Singleton.class);		
+	}
+
+}


### PR DESCRIPTION
When using Guice as a plugin architecture the class may not always be
accessible as in the added test. The disposer should still work.

I'm not primarily a Java developer, but I thought this might be useful.
